### PR TITLE
include d3 js in installation documentation

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -105,7 +105,8 @@
     <p>
       and include it in your webpage as
     </p>
-    <pre><code>&lt;script src=&quot;bower_components/function-plot/dist/function-plot.js&quot;&gt;&lt;/script&gt;</code></pre>
+    <pre><code>&lt;script src=&quot;bower_components/d3/d3.min.js&quot;&gt;&lt;/script&gt;
+&lt;script src=&quot;bower_components/function-plot/dist/function-plot.js&quot;&gt;&lt;/script&gt;</code></pre>
   </div>
 
 <section><div class="container">Examples</div></section>

--- a/site/partials/wzrd.html
+++ b/site/partials/wzrd.html
@@ -1,2 +1,3 @@
 <div class="wzrd-in"><!--p Bundled package ready for production (powered by wzrd.in)a(href=link)= bundle
---><div class="code"><pre><code>&lt;script src=&quot;https://wzrd.in/standalone/function-plot@1.15.0&quot;&gt;&lt;/script&gt;</code></pre></div></div>
+--><div class="code"><pre><code>&lt;script src=&quot;https://d3js.org/d3.v4.min.js&quot;&gt;&lt;/script&gt;
+&lt;script src=&quot;https://wzrd.in/standalone/function-plot@1.15.0&quot;&gt;&lt;/script&gt;</code></pre></div></div>

--- a/site/partials/wzrd.html
+++ b/site/partials/wzrd.html
@@ -1,3 +1,3 @@
 <div class="wzrd-in"><!--p Bundled package ready for production (powered by wzrd.in)a(href=link)= bundle
---><div class="code"><pre><code>&lt;script src=&quot;https://d3js.org/d3.v4.min.js&quot;&gt;&lt;/script&gt;
+--><div class="code"><pre><code>&lt;script src=&quot;https://d3js.org/d3.v3.min.js&quot;&gt;&lt;/script&gt;
 &lt;script src=&quot;https://wzrd.in/standalone/function-plot@1.15.0&quot;&gt;&lt;/script&gt;</code></pre></div></div>


### PR DESCRIPTION
add script tags in the installation documentation that explicitly notes d3 is a dependency. closes #71 