### PR TITLE
Pass index of closest line to custom tip renderer

### DIFF
--- a/lib/tip.js
+++ b/lib/tip.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
   config = extend({
     xLine: false,
     yLine: false,
-    renderer: function (x, y) {
+    renderer: function (x, y, index) {
       return '(' + x.toFixed(3) + ', ' + y.toFixed(3) + ')'
     },
     owner: null
@@ -132,7 +132,7 @@ module.exports = function (config) {
         .attr('fill', color)
       el.select('text')
         .attr('fill', color)
-        .text(config.renderer(x, y))
+        .text(config.renderer(x, y, closestIndex))
     } else {
       tip.hide()
     }


### PR DESCRIPTION
Examples on the site show that renderer accepts index, but in the code it doesn't